### PR TITLE
Add Infrastructure Build and Deploy Workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the asati-dev app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document ###
+### If the container requires any additional pre-build commands, uncomment and edit ###
+### the PREBUILD line at the end of the document. ###
+name: Dev Container Build and Deploy
+on:
+    workflow_dispatch:
+    pull_request:
+        branches:
+            - main
+        paths-ignore:
+            - '.github/**'
+
+jobs:
+    deploy:
+        name: Dev Container Deploy
+        uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+        secrets: inherit
+        with:
+            AWS_REGION: "us-east-1"
+            GHA_ROLE: "asati-gha-dev"
+            ECR: "asati-dev"
+            # FUNCTION: ""
+            # PREBUILD:

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated prod-promote.yml workflow for the asati-prod repository.    ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.           ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: asati-gha-stage
+      GHA_ROLE_PROD: asati-gha-prod
+      ECR_STAGE: "asati-stage"
+      ECR_PROD: "asati-prod"
+      # FUNCTION: ""

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the asati-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document ###
+### If the container requires any additional pre-build commands, uncomment and edit ###
+### the PREBUILD line at the end of the document. ###
+name: Stage Container Build and Deploy
+on:
+    workflow_dispatch:
+    pull_request:
+        branches:
+            - main
+        paths-ignore:
+            - '.github/**'
+
+jobs:
+    deploy:
+        name: Dev Container Deploy
+        uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+        secrets: inherit
+        with:
+            AWS_REGION: "us-east-1"
+            GHA_ROLE: "asati-gha-stage"
+            ECR: "asati-stage"
+            # FUNCTION: ""
+            # PREBUILD:

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
     deploy:
         name: Dev Container Deploy
-        uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+        uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
         secrets: inherit
         with:
             AWS_REGION: "us-east-1"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
     deploy:
-        name: Dev Container Deploy
+        name: Stage Container Deploy
         uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
         secrets: inherit
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 
 RUN pip install --no-cache-dir --upgrade pip pipenv
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y git
 
 COPY Pipfile* /
 RUN pipenv install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 ### This is the Terraform-generated header for asati-dev. If ###
 ### this is a Lambda repo, uncomment the FUNCTION line below ###
 ### and review the other commented lines in the document. ###
-ECR_NAME_DEV:=asati-dev\nECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/asati-dev
+ECR_NAME_DEV:=asati-dev
+ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/asati-dev
 # FUNCTION_DEV:=
 ### End of Terraform-generated header ###
 
@@ -65,13 +66,15 @@ ruff-apply: # Resolve 'fixable errors' with 'ruff'
 ### Terraform-generated Developer Deploy Commands for Dev environment ###
 dist-dev:
 ## Build docker container (intended for developer-based manual build)
-	docker build --platform linux/amd64 \\\n\t -t $(ECR_URL_DEV):latest \\
+	docker build --platform linux/amd64 \\
+		-t $(ECR_URL_DEV):latest \\
 		-t $(ECR_URL_DEV):`git describe --always` \\
 		-t $(ECR_NAME_DEV):latest .
 
 publish-dev: dist-dev
 ## Build, tag and push (intended for developer-based manual publish)
-	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)\n\tdocker push $(ECR_URL_DEV):latest
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
+	docker push $(ECR_URL_DEV):latest
 	docker push $(ECR_URL_DEV):`git describe --always`
 
 ### If this is a Lambda repo, uncomment the two lines below ###

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
+### This is the Terraform-generated header for asati-dev. If ###
+### this is a Lambda repo, uncomment the FUNCTION line below ###
+### and review the other commented lines in the document. ###
+ECR_NAME_DEV:=asati-dev\nECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/asati-dev
+# FUNCTION_DEV:=
+### End of Terraform-generated header ###
 
 help: # Preview Makefile commands
 	@awk 'BEGIN { FS = ":.*#"; print "Usage:  make <target>\n\nTargets:" } \
@@ -55,3 +61,41 @@ black-apply: # Apply changes with 'black'
 
 ruff-apply: # Resolve 'fixable errors' with 'ruff'
 	pipenv run ruff check --fix .
+
+### Terraform-generated Developer Deploy Commands for Dev environment ###
+dist-dev:
+## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \\\n\t -t $(ECR_URL_DEV):latest \\
+		-t $(ECR_URL_DEV):`git describe --always` \\
+		-t $(ECR_NAME_DEV):latest .
+
+publish-dev: dist-dev
+## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)\n\tdocker push $(ECR_URL_DEV):latest
+	docker push $(ECR_URL_DEV):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below ###
+# update-lambda-dev:
+## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
+
+### Terraform-generated manual shortcuts for deploying to Stage. This requires ###
+### that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment ###
+### variables are set locally by the developer and that the developer has ###
+### authenticated to the correct AWS Account. The values for the environment ###
+### variables can be found in the stage_build.yml caller workflow. ###
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \\
+		-t $(ECR_URL_STAGE):latest \\
+		-t $(ECR_URL_STAGE):`git describe --always` \\
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below ###
+# update-lambda-stage:
+## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
### Purpose and background context

This PR adds the infrastructure deploy workflows to the this application, asati. It adds new github automation, and updates the project's Makefile with the new workflows.

A minor change was also made to the Dockerfile directing apt to perform a `dist-upgrade` rather than an `upgrade`. A `dist-upgrade` will attempt to perform all outstanding upgrades with deep dependency resolution and conflict resolution, while an `upgrade` will simply perform outstanding upgrades.

How this addresses that need:

	* Add dev build workflow
	* Add stage build workflow
	* Add prod promotion workflow
	* Update Makefile w/ new workflows
	* Modify Dockerfile to do dist-upgrade

Side effects of this change:

None

Changes to be committed:
      new file:   .github/workflows/dev-build.yml
      new file:   .github/workflows/prod-promote.yml
      new file:   .github/workflows/stage-build.yml
      modified:   Dockerfile
      modified:   Makefile

### How can a reviewer manually see the effects of these changes?

There will be no immediate effect. However, after the PR is merged with `main`, future code updates should allow the running of the deployment workflows.

### Includes new or updated dependencies?

NO

### Changes expectations for external applications?

NO

### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-1148

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

