### PR TITLE
stage container build on merge

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -5,7 +5,7 @@
 name: Stage Container Build and Deploy
 on:
     workflow_dispatch:
-    pull_request:
+    push:
         branches:
             - main
         paths-ignore:


### PR DESCRIPTION
### Purpose and background context

The stage-build.yml is still configured to build and push an ECR image when a PR is opened; it should push an ECR image when there is a push to main, as would happen after the PR is approved and merged. This way, if more commits are added during the PR review process, they will end up in the final ECR image deployed to Stage. Currently stage-build is triggered in the same way as dev-build meaning that any extra commits would not make it to the Stage image.

### How can a reviewer manually see the effects of these changes?

Modifies the build gh workflow to build the prod container on PR merge rather than commit.

### Includes new or updated dependencies?
 NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-1175

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes
